### PR TITLE
增加泛型, 支持 RestTemplate Jackson 正确解析

### DIFF
--- a/src/main/java/com/cdk8s/sculptor/util/response/biz/ResultObject.java
+++ b/src/main/java/com/cdk8s/sculptor/util/response/biz/ResultObject.java
@@ -2,59 +2,65 @@ package com.cdk8s.sculptor.util.response.biz;
 
 import com.cdk8s.sculptor.util.DatetimeUtil;
 
-public class ResultObject {
 
+public class ResultObject<T extends Object> {
+	
 	private int code;
+	
 	private boolean isSuccess;
+	
 	private String msg;
+	
 	private Long timestamp;
-	private Object data;
-
+	
+	private T data;
+	
 	public ResultObject setCode(ResultCodeEnum resultCodeEnum) {
 		this.code = resultCodeEnum.getCode();
 		return this;
 	}
-
+	
 	public long getTimestamp() {
 		if (null == timestamp) {
 			return DatetimeUtil.currentEpochMilli();
 		}
 		return timestamp;
 	}
-
+	
 	public int getCode() {
 		return code;
 	}
-
+	
 	public void setCode(int code) {
 		this.code = code;
 	}
-
+	
 	public boolean getIsSuccess() {
 		return isSuccess;
 	}
-
+	
 	public void setIsSuccess(boolean isSuccess) {
 		this.isSuccess = isSuccess;
 	}
-
+	
 	public String getMsg() {
 		return msg;
 	}
-
+	
 	public void setMsg(String msg) {
 		this.msg = msg;
 	}
-
+	
 	public void setTimestamp(Long timestamp) {
 		this.timestamp = timestamp;
 	}
-
-	public Object getData() {
+	
+	public T getData() {
 		return data;
 	}
-
-	public void setData(Object data) {
+	
+	public void setData(T data) {
 		this.data = data;
 	}
 }
+


### PR DESCRIPTION
@see RestTemplate getForObject 方法获取List,Map 对象时 返回错误的LinkedHashMap
      注意 jackson只知道您想要一个List，但对类型没有任何限制。
      默认情况下，Jackson将JSON对象反序列化为LinkedHashMap，因此这就是为什么要获取的原因ClassCastException。
     (必须用exchange 方法 + ParameterizedTypeReference + 映射类泛型化 指定泛型进行调用)
     https://stackoverflow.com/questions/19463372
     https://www.cnblogs.com/silentdoer/p/9012599.html